### PR TITLE
Switch from Arch Linux to Alpine Linux for smaller images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,19 @@
-FROM base/archlinux:latest
+FROM php:7.0-alpine
 
 MAINTAINER Spencer Rinehart <anubis@overthemonkey.com>
 
-RUN curl -o /etc/pacman.d/mirrorlist "https://www.archlinux.org/mirrorlist/?country=all&protocol=https&ip_version=6&use_mirror_status=on" && sed -i 's/^#//' /etc/pacman.d/mirrorlist
-
-# Update system and install php + composer dependencies (git and openssh for
-# access to repositories)
-RUN pacman-key --refresh-keys && \
-    pacman --sync --refresh --noconfirm --noprogressbar --quiet && \
-    pacman --sync --noconfirm --noprogressbar --quiet archlinux-keyring openssl pacman && \
-    pacman-db-upgrade && \
-    pacman --sync --sysupgrade --noconfirm --noprogressbar --quiet && \
-    pacman --sync --noconfirm --noprogressbar --quiet php git openssh
-
-# Configure the base system.  Timezone is there to silence php's silly
-# warnings.
-COPY timezone.ini /etc/php/conf.d/
+RUN apk add --no-cache --virtual .php-composer-deps git openssh
 
 RUN mkdir /code
 WORKDIR /code
 
-ENV HOME /root
 ENV COMPOSER_HOME $HOME/.composer
 
 # Setup and install composer into the composer global location.  The
 # certificate is installed manually to get around open_basedir restrictions.
 RUN mkdir -p $COMPOSER_HOME/vendor/bin
-RUN curl -sSLo $COMPOSER_HOME/cacert.pem http://curl.haxx.se/ca/cacert.pem
-RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=$COMPOSER_HOME/vendor/bin --filename=composer --cafile=$COMPOSER_HOME/cacert.pem
+RUN curl -sSL https://getcomposer.org/installer | \
+    php -- --install-dir=$COMPOSER_HOME/vendor/bin --filename=composer
 
 # Setup PATH to prioritize local composer bin and global composer bin ahead of
 # system PATH.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a base image for building [PHP][PHP] [composer] packages.
 
 ## Purpose
-This docker image builds on top of Arch Linux's base/archlinux image for the
+This docker image builds on top of the official PHP 7.0-alpine image with the
 purpose of building PHP composer packages.  It provides several key features:
 
 * Access to the build location will be in the volume located at `/code`.  This
@@ -10,9 +10,6 @@ purpose of building PHP composer packages.  It provides several key features:
 * Composer bin directories are automatically included in `PATH`.  Both a
   relative `vendor/bin` directory, and the global `$COMPOSER_HOME/vendor/bin`
   directory are included in the `PATH`.
-* Timezone set to `UTC` by default to remove the warnings with PHP's date and
-  time functions.  This can be overridden by updating
-  `/etc/php/conf.d/timezone.ini`.
 
 ## Usage
 This library is useful with simple `composer.json`'s from the command line.
@@ -73,7 +70,8 @@ process alone could look like this:
 ```dockerfile
 FROM nubs/composer-build
 
-RUN pacman --sync --noconfirm --noprogressbar --quiet xdebug
+RUN apk add --no-cache xdebug && \
+    docker-php-ext-enable xdebug
 ```
 
 You can then build this docker image and run it against your `composer.json`

--- a/timezone.ini
+++ b/timezone.ini
@@ -1,2 +1,0 @@
-[Date]
-date.timezone = UTC


### PR DESCRIPTION
Official docker images are beginning to migrate to Alpine Linux instead of Arch Linux as it is much better suited for Docker's usecases.  The small image sizes and easy configuration make it a preferred distribution for a base.  PHP doesn't get as big of a benefit as other environments because of the desire to bundle the PHP source into the image for easy extension installation, but it does still reduce this image from ~600 MB to ~450 MB which helps.

This switch to the official PHP image also makes it easier to use this image - utilities for installing/enabling PHP extensions are already included and it increases familiarity for users that have used the official image previously.
